### PR TITLE
Add support for Python 3.7 on PyTourch 0.4.1

### DIFF
--- a/convnet_aig.py
+++ b/convnet_aig.py
@@ -14,6 +14,7 @@ import torch.nn as nn
 import torch.nn.functional as F
 import math
 import numpy as np
+from collections import OrderedDict
 from torch.autograd import Variable
 
 from gumbelmodule import GumbleSoftmax

--- a/train.py
+++ b/train.py
@@ -173,7 +173,7 @@ def train(train_loader, model, criterion, optimizer, epoch):
     ttt = torch.autograd.Variable(ttt, requires_grad=False)
     
     for i, (input, target) in enumerate(train_loader):
-        target = target.cuda(async=True)
+        target = target.cuda(non_blocking=True)
         input = input.cuda()
         input_var = torch.autograd.Variable(input)
         target_var = torch.autograd.Variable(target)
@@ -248,7 +248,7 @@ def validate(val_loader, model, criterion, epoch):
 
     end = time.time()
     for i, (input, target) in enumerate(val_loader):
-        target = target.cuda(async=True)
+        target = target.cuda(non_blocking=True)
         input = input.cuda()
         input_var = torch.autograd.Variable(input, volatile=True)
         target_var = torch.autograd.Variable(target, volatile=True)

--- a/train_img.py
+++ b/train_img.py
@@ -217,7 +217,7 @@ def train(train_loader, model, criterion, optimizer, epoch, target_rates):
     ttt = torch.autograd.Variable(ttt, requires_grad=False)
 
     for i, (input, target) in enumerate(train_loader):
-        target = target.cuda(async=True)
+        target = target.cuda(non_blocking=True)
         input = input.cuda()
         input_var = torch.autograd.Variable(input)
         target_var = torch.autograd.Variable(target)
@@ -309,7 +309,7 @@ def validate(val_loader, model, criterion, epoch, target_rates):
 
     end = time.time()
     for i, (input, target) in enumerate(val_loader):
-        target = target.cuda(async=True)
+        target = target.cuda(non_blocking=True)
         input = input.cuda()
         input_var = torch.autograd.Variable(input, volatile=True)
         target_var = torch.autograd.Variable(target, volatile=True)

--- a/utils.py
+++ b/utils.py
@@ -6,8 +6,8 @@
 import os
 import sys
 import time
-import math
 
+import torch
 import torch.nn as nn
 import torch.nn.init as init
 


### PR DESCRIPTION
__async__ is now a reserved word in Python 3.7 and later.  To fix this pytorch/pytorch#4999 changed __cuda(async)__ to __cuda(non_blocking)__ so this PR tracks with that change.

Also added some missing imports.

